### PR TITLE
Changed `save` to use self._state.adding

### DIFF
--- a/jsignature/mixins.py
+++ b/jsignature/mixins.py
@@ -24,7 +24,7 @@ class JSignatureFieldsMixin(models.Model):
 
     def save(self, *args, **kwargs):
 
-        is_new = self.pk is None
+        is_new = self._state.adding
         original = not is_new and self.__class__.objects.get(pk=self.pk)
 
         if self.signature:


### PR DESCRIPTION
Using `self.pk is None` doesn't work for determining if this is a new instance when using UUID as a primary key. It will be generated by the default before the save and appear to never be a new instance

See: https://docs.djangoproject.com/en/1.9/ref/models/instances/#customizing-model-loading
and
http://stackoverflow.com/a/35647389
